### PR TITLE
[Feature] Add support for macOS and older versions of fortune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,20 @@ install:
 	install -Dm 644 $(APPNAME).desktop $(DESTDIR)$(PREFIX)/share/applications/$(APPNAME).desktop
 	install -Dm 644 icon/$(APPNAME).png $(DESTDIR)$(PREFIX)/share/icons/$(APPNAME).png
 
+install-darwin:
+	install -dm 755 /usr/local/bin
+	install -m 755 $(APPNAME) /usr/local/bin/$(APPNAME)
+
+install-darwin-startup:
+	install -m 755 $(APPNAME).plist ~/Library/LaunchAgents/$(APPNAME).plist
+
 uninstall:
 	rm $(DESTDIR)$(PREFIX)/bin/$(APPNAME)
 	rm $(DESTDIR)$(PREFIX)/share/applications/$(APPNAME).desktop
 	rm $(DESTDIR)$(PREFIX)/share/icons/$(APPNAME).png
+
+uninstall-darwin:
+	rm /usr/local/bin/$(APPNAME)
+
+uninstall-darwin-startup:
+	rm ~/Library/LaunchAgents/$(APPNAME).plist

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License][License-Image]][License-URL] [![ReportCard][ReportCard-Image]][ReportCard-URL] [![Build][Build-Status-Image]][Build-Status-URL] [![Release][Release-Image]][Release-URL]
 
-**Fortunate** is an open-source motivational app for Linux that delivers uplifting quotes and thoughtful messages. Powered by `fortune-mod`, it offers both a clean graphical interface and system notifications to keep you inspired throughout your day.
+**Fortunate** is an open-source motivational app for Linux and macOS that delivers uplifting quotes and thoughtful messages. Powered by `fortune-mod`, it offers both a clean graphical interface and system notifications to keep you inspired throughout your day.
 
 ![Screenshot](screenshot.png)
 
@@ -62,6 +62,14 @@ sudo apt-get install git make golang gcc libgl1-mesa-dev xorg-dev fortune-mod
 sudo dnf install git make golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel fortune-mod
 ```
 
+**macOS**
+
+First install XCode and then execute:
+
+```bash
+brew install golang fortune
+```
+
 ### Build and Install
 
 ```bash
@@ -74,8 +82,14 @@ cd fortunate
 # Build the project
 make
 
-# Install system-wide
+# Linux Install
 sudo make install
+
+# macOS Install
+make install-darwin
+
+# macOS LaunchAgent Install
+make install-darwin-startup
 ```
 
 ## Usage
@@ -83,9 +97,21 @@ sudo make install
 ### Basic Usage
 
 - Launch Fortunate from your applications menu or run `fortunate` in your terminal
-- The application runs in your system tray (look for the lotus icon)
+- The application runs in your system tray or menubar (look for the lotus icon)
+
+**System Tray**
+
 - Left-click the tray icon to display a fortune
 - Right-click the tray icon to access the menu:
+  - Display Fortune
+  - Notify Fortune
+  - Settings
+  - About
+  - Quit
+
+**Menubar**
+
+- Click the menubar icon to access the menu:
   - Display Fortune
   - Notify Fortune
   - Settings
@@ -129,8 +155,10 @@ This repository includes additional custom fortune collections located in `fortu
 ### Installation
 
 The fortune directory location varies by distribution:
+
 - Debian/Ubuntu/Fedora: `/usr/share/games/fortunes/`
 - Arch Linux: `/usr/share/fortune/`
+- macOS: `/usr/local/share/games/fortunes`
 
 Copy the fortune files to your system's fortune directory:
 
@@ -140,6 +168,12 @@ sudo cp fortunes/* /usr/share/games/fortunes/
 
 # For Arch Linux
 sudo cp fortunes/* /usr/share/fortune/
+
+# For macOS
+cp fortunes/* /usr/local/share/games/fortunes/
+strfile /usr/local/share/games/fortunes/appreciation
+strfile /usr/local/share/games/fortunes/inspiration
+strfile /usr/local/share/games/fortunes/motivation
 ```
 
 Note: You may need to check your specific distribution's fortune directory location if it differs from these common paths.

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 const (
 	AppName    = "fortunate"
 	GUIAppName = "Fortunate"
-	Version    = "1.0.1"
+	Version    = "1.0.2"
 )
 
 // Config type for application configuration.

--- a/fortunate.plist
+++ b/fortunate.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin</string>
+    </dict>
+    <key>Label</key>
+    <string>at.greyh.fortunate</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/fortunate</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>

--- a/fortune/fortune_windows.go
+++ b/fortune/fortune_windows.go
@@ -2,7 +2,13 @@
 
 package fortune
 
-import "errors"
+import (
+	"errors"
+)
+
+var (
+	CookieSupported = false
+)
 
 // Run runs fortune.
 func Run() (string, string, error) {
@@ -12,4 +18,9 @@ func Run() (string, string, error) {
 // Lists returns a list of installed fortune lists.
 func Lists() ([]string, error) {
 	return []string{}, errors.New("not supported")
+}
+
+// CheckCookieSupported checks if the locally installed fortune supports cookie display.
+func CheckCookieSupported() error {
+	return errors.New("not supported")
 }

--- a/fyneapp/activationpolicy.go
+++ b/fyneapp/activationpolicy.go
@@ -1,0 +1,7 @@
+//go:build linux || dragonfly || freebsd || netbsd || openbsd || windows
+
+package fyneapp
+
+func setActivationPolicy() {
+	return
+}

--- a/fyneapp/activationpolicy_darwin.go
+++ b/fyneapp/activationpolicy_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package fyneapp
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#import <Cocoa/Cocoa.h>
+
+int
+SetActivationPolicy(void) {
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    return 0;
+}
+*/
+import "C"
+
+func setActivationPolicy() {
+	C.SetActivationPolicy()
+}

--- a/fyneapp/fyneapp.go
+++ b/fyneapp/fyneapp.go
@@ -2,6 +2,7 @@ package fyneapp
 
 import (
 	"github.com/zquestz/fortunate/config"
+	"github.com/zquestz/fortunate/fortune"
 	"github.com/zquestz/fortunate/icon"
 
 	"fyne.io/fyne/v2"
@@ -33,7 +34,12 @@ func Run() {
 	setSystrayIcon()
 	setActivate()
 
+	fortune.CheckCookieSupported()
 	go startFortuneTicker()
+
+	appGUI.Lifecycle().SetOnStarted(func() {
+		setActivationPolicy()
+	})
 
 	appGUI.Run()
 }

--- a/fyneapp/settings.go
+++ b/fyneapp/settings.go
@@ -34,6 +34,11 @@ func settings() {
 	fortuneLength := container.NewHBox(shortFortunes, longFortunes)
 
 	showCookie := widget.NewCheck("", nil)
+
+	if !fortune.CookieSupported {
+		config.AppConfig.ShowCookie = false
+	}
+
 	showCookie.SetChecked(config.AppConfig.ShowCookie)
 
 	lists, err := fortune.Lists()
@@ -75,12 +80,16 @@ func settings() {
 			{Text: "Icon Theme", Widget: iconTheme},
 			{Text: "Fortune Timer", Widget: notifyFortuneTimes},
 			{Text: "Fortune Length", Widget: fortuneLength},
-			{Text: "Show Cookie", Widget: showCookie},
-			{Text: "Fortune Lists", Widget: scrollableLists},
 		},
 		OnCancel: cancelFunc,
 		OnSubmit: submitFunc,
 	}
+
+	if fortune.CookieSupported {
+		form.Items = append(form.Items, &widget.FormItem{Text: "Show Cookie", Widget: showCookie})
+	}
+
+	form.Items = append(form.Items, &widget.FormItem{Text: "Fortune Lists", Widget: scrollableLists})
 
 	newSettingsWindow.Canvas().SetOnTypedKey(func(key *fyne.KeyEvent) {
 		switch key.Name {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.23.2
 require (
 	fyne.io/fyne/v2 v2.5.2
 	fyne.io/systray v1.11.0
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/zquestz/go-ucl v0.0.0-20220615095619-8a3686d7543a

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
- Added support for macOS.
- Added support for ancient versions of fortune.
- Updated docs for new macOS support.
- Show Cookie setting only shows if the installed version of fortune supports it.

Fixes: https://github.com/zquestz/fortunate/issues/2